### PR TITLE
README.md: Go brrrrrr (significant formatting updates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,48 @@
+# Sloth
+
 <a href="https://repo.dairy.foundation/#/releases/dev/frozenmilk/sinister/Sloth" target="_blank">
 <img src="https://repo.dairy.foundation/api/badge/latest/releases/dev/frozenmilk/sinister/Sloth?color=40c14a&name=Sloth" />
 </a>
 
 Sloth is the fastest hot code reload library for FTC.
 
-Hot reloading involves sending just your teamcode to the robot when you make a
-change to get VERY fast write -> run -> test development cycles. Say good bye to
-waiting 40 seconds + for your teamcode to be uploaded, Sloth gets code on your
-robot in under a second.
+Hot reloading involves sending only your teamcode to the robot when you make a
+change, to get *very* fast Write -> Run -> Test development cycles. Say goodbye to
+waiting 40+ seconds for your teamcode to be uploaded, Sloth gets code on your
+robot in ***under a second***.
 
-Sloth is also Sinister runtime that enables the use of Sinister's classpath
-scanning and dynamic loading capabilities on the android FTC platform. This
-allows Sloth to support a wide range of libraries that need to know about and
-react to hot reloading your code.
+Sloth is also a [Sinister](https://docs.dairy.foundation/Sinister/overview)
+runtime that enables the use of Sinister's classpath scanning and dynamic
+loading capabilities on the android FTC platform. This allows Sloth to
+support a wide range of libraries that need to know about and react to hot
+reloading your code.
 
 Sloth has some major improvements over its predecessor, [fastload](https://github.com/MatthewOates36/fast-load):
-1. Sloth is much faster than fastload. fastload advertises ~7 seconds upload time, Sloth has a upper ceiling of 2 seconds, but often is less than 1.
-2. Sloth will keep changes across restarts and power cycles of the robot.
-3. `@Pinned` can be put on classes to prevent dynamically changing it, or any subclasses of it.
-4. Sloth is a more capable runtime, that does more than just swap over your code:
-    - Sloth sets up Dairy.
-    - Updates parts of the SDK properly when you upload code changes, including
-      your hardwaremap if you're uploading drivers with your teamcode. (like the
-      gobilda pinpoint driver before it was part of the sdk).
-    - Libraries that rely on looking at your code, like dashboard, can be easily
-      tweaked to be compatible with Sloth, and thus load faster, and support
-      hotreloading. (please open an issue if you have a favourite library that
-      is currently incompatible with Sloth, I don't mind maintaining a fork, or
-      doing the setup work to make it easy for others to maintain.)
+1. Sloth is **much faster** than fastload. fastload advertises ~7 seconds
+   upload time; Sloth has a upper ceiling of 2 seconds, but often is less than 1.
+3. Sloth will **keep changes across restarts and power cycles of the robot**.
+4. Sloth only processes the change in code when your OpMode ends, which means
+   **it is safe to deploy with Sloth while running other code**.
+6. `@Pinned` can be put on classes to prevent dynamically changing it, or any subclasses of it.
+7. Sloth is a more capable runtime, that does more than just swap over your code:
+    - Sloth sets up [Dairy](https://docs.dairy.foundation/introduction).
+    - Sloth updates parts of the SDK properly when you upload code changes, including
+      your hardwaremap if you're uploading drivers with your teamcode (e.g. the
+      goBILDA Pinpoint driver before it was part of the SDK).
+    - Libraries that rely on looking at your code, like
+      [FTC Dashboard](https://github.com/acmerobotics/ftc-dashboard), can be
+      easily tweaked to be compatible with Sloth, and thus load faster, and
+      support hotreloading. (Please open an issue if you have a favourite library
+      that is currently incompatible with Sloth; I don't mind maintaining a fork,
+      or doing the setup work to make it easy for others to maintain.)
     - Sloth supports custom user classpath scanning, so you can write your own
       systems that listen and react to hot reloads.
-5. Sloth has a drop-in replacement of Dashboard that replaces some internal mechanisms of Dashboard to use Sloth and Sinister equivalents.
+8. Sloth includes a drop-in replacement of FTC Dashboard that replaces some internal
+   mechanisms of FTC Dashboard to use the Sloth and Sinister equivalents.
    This fork fully supports hot reloading for Configuration (`@Config`) and OpModes.
-6. Sloth only processes the change in code when your OpMode ends, which means its safe to deploy with Sloth while running other code.
 
 There are some precautions to take when using Sloth:
-1. Sloth will only dynamically hot reload classes in the `org.firsinspires.ftc.teamcode` package, and subpackages.
+1. Sloth will only dynamically hot reload classes in the `org.firsinspires.ftc.teamcode` package (and subpackages).
 2. It is possible to upload code that compiles, but does not work when hot reloaded due to:
    - Installing or changing libraries.
    - Changing files that are not hot reloaded.
@@ -43,18 +50,20 @@ There are some precautions to take when using Sloth:
    Be careful to ensure that you make changes that will be changed, and if make changes that will not,
    that you perform a full install in order to propagate them.
 
-WARNING: IF YOU HAVE USED THE PEDRO QUICKSTART, PLEASE MOVE YOUR FILES TO THE
-`org.firstinspires.ftc.teamcode` PACKAGE. THE SECOND MOST COMMON ERROR I SEE IS
-USING THE PEDRO QUICKSTART. THEY WILL NOT FIX THIS ISSUE.
+> [!WARNING]
+> If you used an older version of the Pedro Pathing quickstart, you will need
+> to move your files to the `org.firstinspires.ftc.teamcode` package.
 
 # Installation
 
-NOTE: if you are using Dairy, skip to the Dairy Core Heading
+> [!IMPORTANT]
+> If you are already using Dairy, skip straight to the [Dairy Core](#dairy-core) section.
 
-NOTE: if you are using Dashboard, check out the Dashboard heading.
+> [!NOTE]
+> If you are using FTC Dashboard, check out the [FTC Dashboard](#ftc-dashboard) section.
 
 ## Sloth Library
-add the dairy releases repository to your `TeamCode` `build.gradle`, above the `dependencies` block
+Add the dairy releases repository to your `TeamCode` `build.gradle`, above the `dependencies` block:
 ```groovy
 repositories {
     maven {
@@ -63,19 +72,19 @@ repositories {
 }
 ```
 
-then add sloth to the `dependencies` block:
+Then add sloth to the `dependencies` block:
 ```groovy
 dependencies {
     implementation("dev.frozenmilk.sinister:Sloth:0.2.4")
 }
 ```
 
-now install the Load Plugin
+Now [install the Load plugin](#load-plugin).
 
 ## Dairy Core
-to use this release of Sloth with Dairy you need to install a snapshot version of Dairy's Core
+To use this release of Sloth with Dairy you need to install a snapshot version of Dairy's Core.
 
-add the dairy releases and snapshots repository to your `TeamCode` `build.gradle`, above the `dependencies` block
+Add the Dairy releases and snapshots repository to your `TeamCode` `build.gradle`, above the `dependencies` block:
 ```groovy
 repositories {
     maven {
@@ -87,21 +96,22 @@ repositories {
 }
 ```
 
-then add core to the `dependencies` block:
+Then add core to the `dependencies` block:
 ```groovy
 dependencies {
     implementation("dev.frozenmilk.dairy:Core:2.2.4")
 }
 ```
 
-NOTE: you do not need to install Sloth as well, and if you currently have any installations of either
-`"dev.frozenmilk.dairy:Util"` or `"dev.frozenmilk:Sinister"` then you need to remove those, this Core
-version will provide the correct versions of these libraries.
+> [!WARNING]
+> You do not need to install Sloth as well, and if you currently have any installations of either
+> `"dev.frozenmilk.dairy:Util"` or `"dev.frozenmilk:Sinister"` then you need to remove those, as this Core
+> version will provide the correct versions of these libraries.
 
-now install the Load Plugin
+Now [install the Load plugin](#load-plugin).
 
 ## Load Plugin
-add this to the top of your `TeamCode` `build.gradle`
+Add this to the top of your `TeamCode` `build.gradle`:
 ```groovy
 buildscript {
     repositories {
@@ -116,20 +126,20 @@ buildscript {
 }
 ```
 
-add this after the apply lines in the same file
+Add this after the `apply plugin:` lines in the same file:
 ```groovy
-// there should be 2 or 3 more lines that start with apply here
+// there should be 2 or 3 more lines that start with 'apply plugin:' here
 apply plugin: 'dev.frozenmilk.sinister.sloth.load'
 ```
 
-sync and download onto your robot via standard install
+Sync and download the code onto your robot via standard install.
 
-now add the gradle tasks
+Now [add the Gradle tasks](#gradle-tasks).
 
-NOTE: if you use dashboard, install that now, then setup the gradle tasks
+NOTE: If you use FTC Dashboard, install that now, then setup the gradle tasks:
 
-## Dashboard
-add the dairy releases repository to your `TeamCode` `build.gradle`, above the `dependencies` block (if you already have it, no need to do so again)
+## FTC Dashboard
+Add the dairy releases repository to your `TeamCode` `build.gradle`, above the `dependencies` block (if you already have it, no need to do so again)
 ```groovy
 repositories {
     maven {
@@ -138,18 +148,19 @@ repositories {
 }
 ```
 
-then add dashboard to the `dependencies` block:
+Then add dashboard to the `dependencies` block:
 ```groovy
 dependencies {
     implementation("com.acmerobotics.slothboard:dashboard:0.2.4+0.4.17")
 }
 ```
 
-NOTE: if you use a library that imports dashboard via a `implementation` or `api` dependency:
+> [!NOTE]
+> If you use a library that imports dashboard via a `implementation` or `api` dependency,
+> ask the library maintainers to consider changing it to `compileOnly`.  This will allow
+> it to work with the modified version of FTC Dashboard that Sloth uses.
 
-ask the library maintainers to consider changing it to `compileOnly`
-
-change the `implementation` like so:
+Change the `implementation` like so:
 ```groovy
 implementation("com.pedropathing:pedro:1.0.8") {
    exclude group: "com.acmerobotics.dashboard"
@@ -163,46 +174,48 @@ implementation ("com.acmerobotics.roadrunner:actions:1.0.1"){
    exclude group: "com.acmerobotics.dashboard"
 }
 ```
-note that both pedro and rr require this.
+Note that both Pedro Pathing and Road Runner require this.
 
-_pedro and rr version numbers may not be up to date._
+_Pedro Pathing and Road Runner version numbers may not be up to date; they are provided only as an example._
 
 ## Gradle Tasks
 
-edit configurations:
+Edit configurations:
 
 ![](image/edit_configurations.png)
 
-add new configuration:
+Add new configuration:
 
 ![](image/add_new_configuration.png)
 
-select gradle:
+Select gradle:
 
 ![](image/add_new_gradle_configuration.png)
 
-add `deploySloth` and save it:
+Add `deploySloth` and save it:
 
 ![](image/add_deploySloth_task.png)
 NOTE: android studio will not auto complete the names of these tasks, just write it and it will work.
 
-edit TeamCode configuration:
+Edit TeamCode configuration:
 
 ![](image/edit_TeamCode_configuration.png)
 
-add new gradle task:
+Add new gradle task:
 
 ![](image/run_gradle_task.png)
 
-add `removeSlothRemote`:
+Add `removeSlothRemote`:
 
 ![](image/add_removeSlothRemote_task.png)
 
-note: type `:TeamCode` into the `Gradle Project` box to get the right contents,
-do not copy mine.
+Note: Type `:TeamCode` into the `Gradle Project` box to get the right contents,
+**do not copy mine**.
 
-put `removeSlothRemote` first and save:
+Put `removeSlothRemote` first and save:
 
 ![](image/ensure_order.png)
 
 Run the deploySloth task you just added to deploy the code.
+
+Congratulations!  You are now set up with lightning-fast software deployment using Sloth.


### PR DESCRIPTION
The Pedro Pathing package location issue was fixed in https://github.com/Pedro-Pathing/Quickstart/commit/9c2e84ca51f865a96c119acdd4ebd7dd96c5f37f + https://github.com/Pedro-Pathing/Quickstart/commit/bfb5780f94727886110feeedecedc393719ca2d5 on the master branch, and https://github.com/Pedro-Pathing/Quickstart/commit/bf00e9aa45f8229aa1273021c9b6d7b041d5cad0 on the dev branch.